### PR TITLE
Remove media control to get v4l2-ctrls from sensor

### DIFF
--- a/source/imx385_327-overlay.dtsi
+++ b/source/imx385_327-overlay.dtsi
@@ -24,7 +24,6 @@
 		target = <&csi1>;
 		csi: __overlay__ {
 			status = "okay";
-			brcm,media-controller;
 
 			port {
 				csi_ep: endpoint {
@@ -94,7 +93,6 @@
 				  <&cam_node>,"clock-frequency:0";
 		rotation = <&cam_node>,"rotation:0";
 		orientation = <&cam_node>,"orientation:0";
-		media-controller = <&csi>,"brcm,media-controller?";
 		cam0 = <&i2c_frag>, "target:0=",<&i2c_vc>,
 		       <&csi_frag>, "target:0=",<&csi0>,
 		       <&clk_frag>, "target:0=",<&cam0_clk>,


### PR DESCRIPTION
Signed-off-by: Tejas Patel <tejaspatel.12@outlook.com>